### PR TITLE
Add JSONValue type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,3 +23,11 @@ export type ToRequired<T> = {
 }
 
 export type ToOptional<T> = { [K in keyof T]?: T[K] }
+
+export type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: JSONValue }
+  | JSONValue[]


### PR DESCRIPTION
Would be useful for e.g. https://github.com/paritytech/gitspiegel/pull/92#pullrequestreview-1018173157 as a sane response type for JSON APIs.

As far as I'm aware TypeScript doesn't offer this as a built-in type.