### PR TITLE
Ports and commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./format";
 export * from "./github";
 export * from "./http";
 export * from "./logger";
+export * from "./net";
 export * from "./normalization";
 export * from "./shell";
 export * from "./time";

--- a/src/net.ts
+++ b/src/net.ts
@@ -1,0 +1,54 @@
+import * as net from "net";
+
+/**
+ * As we need to find unused ports for testing of our bots, we also need to know them in the test environment,
+ *  which means that we can't just let bot listen on port 0,
+ *  because we don't have a proper backchannel to understand which ports are used
+ *
+ *  This function spawns `net.server`s on port 0, gets, which ports they used, and frees it.
+ *  Unlike using port 0, this approach doesn't really guarantee that port will be free until app starts listening,
+ *  but should be pretty stable
+ *
+ *  A caveat here: if you free a port and try getting a new one in a row, you might get the same one,
+ *  thus, spawning multiple servers together, and closing them together as well
+ */
+export async function findFreePorts(amount: number): Promise<number[]> {
+  const servers: net.Server[] = [];
+
+  while (servers.length < amount) {
+    servers.push(net.createServer());
+  }
+  const ports = await Promise.all(
+    servers.map(
+      (srv) =>
+        new Promise<number>((res, rej) =>
+          srv.listen(0, () => {
+            const addr = srv.address();
+            if (addr === null || typeof addr === "string") {
+              rej(addr);
+            } else {
+              res(addr.port);
+            }
+          }),
+        ),
+    ),
+  );
+  await Promise.all(servers.map((srv) => new Promise<void>((res) => srv.close(() => res()))));
+  return ports;
+}
+
+/**
+ * Tries to connect to port, and resolves to `true` if successful.
+ * Designed to be used together with `until` function from neighbour `time` module.
+ */
+export function pingPort(host: string, port: number): Promise<boolean> {
+  const conn = net.connect({ port, host, allowHalfOpen: false });
+
+  return new Promise((resolve) => {
+    conn.once("connect", () => {
+      conn.destroy();
+      resolve(true);
+    });
+    conn.once("error", () => resolve(false));
+  });
+}


### PR DESCRIPTION
Two updates that are used in integration tests

* `findFreePorts` enable us to get batch of free ports, in
order to use it for testing environment. Moved from command-bot tests.
* `pingPort` allows us to check if somebody listens on provided port,
useful to understand if service under test is ready to accept requests.
* `writePidfile` / `ensureDeadByPidfile` allows us to kill remnants of
test harness of the last run, before spawning new one
* `killAndWait` also moved from `command-bot` tests.
* Also, updated shell command runner logging, as it's really hard to
understand, which command exited/was killed
