### PR TITLE
ci: added github-issue-sync action

### DIFF
--- a/.github/workflows/github-issue-sync.yml
+++ b/.github/workflows/github-issue-sync.yml
@@ -1,0 +1,32 @@
+name: GitHub Issue Sync
+
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+  workflow_dispatch:
+    inputs:
+      excludeClosed:
+        description: 'Exclude closed issues in the sync.'
+        type: boolean
+        default: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.PROJECT_APP_ID }}
+          private_key: ${{ secrets.PROJECT_APP_KEY }}
+      - name: Sync issues
+        uses: paritytech/github-issue-sync@v0.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_TOKEN: ${{ steps.generate_token.outputs.token }}
+          project: 16
+          project_field: Tool
+          project_value: generic

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository hosts shared functionality for
 [OpsTooling](https://github.com/orgs/paritytech/teams/opstooling) projects.
 
+![GitHub Issue Sync](https://github.com/paritytech/opstooling-js/actions/workflows/github-issue-sync.yml/badge.svg)
+
 # Installation
 
 Choose a [tag](https://github.com/paritytech/opstooling-js/tags) and then run


### PR DESCRIPTION
Blocked until https://github.com/paritytech/internal_it/issues/182 is resolved.

Created GitHub action with `GitHub Issue Sync`.

Issues will be assigned to [OpsTooling Board](https://github.com/orgs/paritytech/projects/16).

Added `README` badge so we can visualize the action working.