### PR TITLE
Proposal: Replace Ok and Err classes with interfaces

### DIFF
--- a/src/github/octokit.ts
+++ b/src/github/octokit.ts
@@ -8,7 +8,7 @@ import { Mutex } from "async-mutex";
 import { githubApiEndpoints } from "src/github/api";
 import { Logger } from "src/logger";
 import { delay } from "src/time";
-import { Err, Ok, err, ok } from "src/types";
+import { Err, err, Ok, ok } from "src/types";
 
 const wasOctokitExtendedByApplication = Symbol();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,14 +1,20 @@
-export class Ok<T> {
-  constructor(public value: T) {}
+export interface Ok<T> {
+  kind: "Ok";
+  value: T;
 }
 
-export const ok = <T>(value: T): Ok<T> => new Ok(value);
+export const ok = <T>(value: T): Ok<T> => {
+  return { kind: "Ok", value };
+};
 
-export class Err<T> {
-  constructor(public value: T) {}
+export interface Err<T> {
+  kind: "Err";
+  value: T;
 }
 
-export const err = <T>(value: T): Err<T> => new Err(value);
+export const err = <T>(value: T): Err<T> => {
+  return { kind: "Err", value };
+};
 
 type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T];
 type RequiredKeys<T> = Exclude<KeysOfType<T, Exclude<T[keyof T], undefined>>, undefined>;


### PR DESCRIPTION
## The (potential) problem

I worry that relying on `instanceof Ok/Err` in packages consuming `opstooling-js` can be dangerous.

[Example usage](https://github.com/paritytech/gitspiegel/blob/9e5c9024510d189ff0bd6ae30bfe453c8acd0823/src/database.ts#L240)

It is safe if the class is declared in your code, but if the class is declared in a dependency I think it's not always safe.

## Multiple `opstooling-js` in node_modules

```bash
yarn add  --network-concurrency 1 --dev https://github.com/paritytech/opstooling-js#v0.0.16
yarn add  --network-concurrency 1 --dev https://github.com/paritytech/opstooling-testing
```

That's it, there now exist two different `opstooling-js` packages in node_modules.
Can we be sure that when doing `something instanceof Err` both left-side value and right-side type are coming from the same package?
I'm not so sure, I've run into problems like this before, but maybe I'm missing something.

## The proposed solution

Replace the `Ok/Err` classes with interfaces.
Now you cannot do `result instanceof Ok`, you have to do `result.kind === "Ok"`, which I think resolves this potential problem.