### PR TITLE
add import dist to exports in package.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "import": "./dist/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }


### PR DESCRIPTION

Fix `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in` in chain-wide-payouts