### PR TITLE
Stop spamming with Ok | Err deprecation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,13 @@
-const deprecateOkErr = () =>
+let deprecateOkErrShown = false;
+
+const deprecateOkErr = () => {
+  if (deprecateOkErrShown) return;
   console.warn(
     "The usage of the Ok/Err pattern is deprecated because of the danger of mismatched 'instanceof' types in node_modules. " +
       "Please use the regular try-catch pattern.",
   );
+  deprecateOkErrShown = true;
+};
 
 /**
  * @deprecated


### PR DESCRIPTION
Currently, it logs every usage of the deprecated feature, cluttering
logs terribly
