### PR TITLE
Allowing empty secrets in addSecretsToMask(...)

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -31,8 +31,12 @@ export class Logger {
 
   constructor(public options: LoggerOptions) {}
 
-  addSecretsToMask(...secrets: string[]): void {
-    this.#secretsToMask.push(...secrets);
+  addSecretsToMask(...secrets: (string | undefined)[]): void {
+    for (const value of secrets) {
+      if (value !== undefined && value !== "") {
+        this.#secretsToMask.push(value);
+      }
+    }
   }
 
   getFastifyLogger(): FastifyLoggerInstance {


### PR DESCRIPTION
Secrets are likely to come from environment variables, and instead of
validating them on each use, it'd be easier to handle this case here
