### PR TITLE
Move prom-client to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/node-fetch": "^2.6.1",
     "fastify": "^3.29.0",
     "jest": "^29.1.0",
+    "prom-client": "^14.2.0",
     "ts-jest": "^29.0.3",
     "ts-patch": "^2.1.0",
     "typedoc": "^0.24.8",
@@ -56,7 +57,6 @@
     "joi": "^17.6.4",
     "joi-to-typescript": "^4.0.5",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.6.7",
-    "prom-client": "^14.2.0"
+    "node-fetch": "^2.6.7"
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,5 +1,5 @@
 import type { FastifyLoggerInstance } from "fastify";
-import { Counter } from "prom-client";
+import type { Counter } from "prom-client";
 import { inspect } from "util";
 
 export type LoggingImplementation = {


### PR DESCRIPTION
The dependency is pulled in even if you don't use it, but we only use it for the type.
With this change it'll be consistent with how we deal with `fastify` dependency.