### PR TITLE
Removing node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.17.0",
     "@types/node": "^20.12.8",
-    "@types/node-fetch": "^2.6.11",
     "fastify": "^4.26.2",
     "jest": "^29.7.0",
     "prom-client": "^15.1.2",
@@ -56,7 +55,6 @@
     "deepdash": "^5.3.9",
     "joi": "^17.13.1",
     "joi-to-typescript": "^4.13.0",
-    "lodash": "^4.17.21",
-    "node-fetch": "^3.3.2"
+    "lodash": "^4.17.21"
   }
 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,5 +1,4 @@
 import Joi from "joi";
-import fetch, { RequestInfo, RequestInit } from "node-fetch";
 
 import { validate } from "./validation";
 
@@ -9,7 +8,7 @@ export type ValidatedFetchParams = {
 };
 
 export const validatedFetch = async <T>(
-  url: RequestInfo,
+  url: Request,
   schema: Joi.Schema<T>,
   { decoding, init }: ValidatedFetchParams = {},
 ): Promise<T> => {


### PR DESCRIPTION
in the latest release, node-fetch was updated to ^3, which made this
package incompatible with commonjs.
Meanwhile, with nodejs@^20, both fetch API and the corresponding types
seem to be working just fine without external dependencies
