### PR TITLE
Handle temporary disconnections in the `runtimeRestarter`

### DIFF
--- a/src/runtimeRestarter.ts
+++ b/src/runtimeRestarter.ts
@@ -68,9 +68,21 @@ export function runtimeRestarter(opts: {
     }
   };
 
+  const tryRunChecks = async () => {
+    try {
+      await runChecks();
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("WebSocket is not connected")) {
+        log?.("Failed to check for metadata/runtime changes due to disconnected websocket. Will continue trying.");
+        return;
+      }
+      throw e;
+    }
+  };
+
   const checkIntervalSeconds = opts.checkIntervalSeconds ?? 600;
   const interval = setInterval(() => {
-    void runChecks();
+    void tryRunChecks();
   }, checkIntervalSeconds * 1000);
 
   return () => clearInterval(interval);


### PR DESCRIPTION
Some apps using the `runtimeRestarter` are prepared to handle temporary disconnections to the chain.

However, the current implementation of `runtimeRestarter` will cause an unhandled error and a crash in such a case.

I'm proposing to not throw an error on those disconnections, which are quite frequent. The checks will continue when the socket reconnects.