### PR TITLE
ci: Upgrade actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: npm pack
         run: npm pack
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: package
           path: "eng-automation-js-*.tgz"


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024, updating them.

cc https://github.com/paritytech/ci_cd/issues/1078